### PR TITLE
Fixed error in applyExifRotation()

### DIFF
--- a/src/file-upload/fileTools.ts
+++ b/src/file-upload/fileTools.ts
@@ -145,7 +145,6 @@ export function applyExifRotation(
     
     return fixFileOrientationByMeta(file,result)
   })
-  .then(()=>file)
 }
 
 export function readOrientation(


### PR DESCRIPTION
Return the processed image (with applied EXIF rotation) and not the original image.