### PR TITLE
Fix touch error on Chrome Mobile

### DIFF
--- a/src/file-upload/doc-event-help.functions.ts
+++ b/src/file-upload/doc-event-help.functions.ts
@@ -20,8 +20,9 @@ export const detectSwipe = function(evt:any):boolean {
         if ((Math.abs(currentX - initialTouchStartX) > 20) ||
           (Math.abs(currentY - initialTouchStartY) > 20)) {
           evt.stopPropagation();
-          evt.preventDefault();
-          return false;
+          if (evt.cancelable) {
+            evt.preventDefault();
+          }
         }
       }
       return true;


### PR DESCRIPTION
Fixed error "Ignored attempt to cancel a touchend event with cancelable=false" and opening dialog while touch and scroll page on Chrome Mobile.